### PR TITLE
Fixes en queries de estadisticas

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -275,11 +275,21 @@ async function load() {
     },
   });
 
+  const octoberDate = new Date('2023-10-5');
+  const novemberDate = new Date('2023-11-18');
+  const decemberDate = new Date('2023-12-22');
+  const januaryDate = new Date('2024-01-10');
+  const februaryDate = new Date('2024-02-10');
+  const marchDate = new Date('2024-03-10');
+  const aprilDate = new Date('2024-04-10');
+  const mayDate = new Date('2024-05-10');
+
   const groupReading1 = await prisma.evaluationGroupReading.create({
     data: {
       reading_id: testReading1.id,
       evaluation_group_id: testTeacher.GroupsOwned[0].id,
-      due_date: new Date('2024-08-10'),
+      due_date: decemberDate,
+      created_at: octoberDate,
     },
   });
 
@@ -287,7 +297,8 @@ async function load() {
     data: {
       reading_id: testReading2.id,
       evaluation_group_id: testTeacher.GroupsOwned[0].id,
-      due_date: new Date('2024-10-10'),
+      due_date: mayDate,
+      created_at: novemberDate,
     },
   });
 
@@ -295,105 +306,182 @@ async function load() {
     data: {
       reading_id: testReading3.id,
       evaluation_group_id: testTeacher.GroupsOwned[0].id,
-      due_date: new Date('2024-09-10'),
+      due_date: januaryDate,
+      created_at: decemberDate,
     },
   });
 
-  const octoberDate = new Date('2023-10-5');
-  const novemberDate = new Date('2023-11-18');
-  const decemberDate = new Date('2023-12-22');
-
-  await addStudentReading(
-    1,
-    groupReading1.id,
-    groupReading1.reading_id,
-    octoberDate,
-  );
-  await addStudentReading(
-    1,
-    groupReading2.id,
-    groupReading2.reading_id,
-    octoberDate,
-  );
-  await addStudentReading(
-    1,
-    groupReading3.id,
-    groupReading3.reading_id,
-    novemberDate,
-  );
-  await addStudentReading(
-    1,
-    groupReading1.id,
-    groupReading1.reading_id,
-    novemberDate,
-  );
-  await addStudentReading(
-    1,
-    groupReading1.id,
-    groupReading1.reading_id,
-    decemberDate,
-  );
-  await addStudentReading(
-    1,
-    groupReading1.id,
-    groupReading1.reading_id,
-    decemberDate,
-  );
-
-  await addStudentReading(
-    2,
-    groupReading1.id,
-    groupReading1.reading_id,
-    octoberDate,
-  );
-  await addStudentReading(
-    2,
-    groupReading2.id,
-    groupReading2.reading_id,
-    octoberDate,
-  );
-  await addStudentReading(
-    2,
-    groupReading3.id,
-    groupReading3.reading_id,
-    novemberDate,
-  );
-  await addStudentReading(
-    2,
-    groupReading1.id,
-    groupReading1.reading_id,
-    novemberDate,
-  );
-  await addStudentReading(
-    2,
-    groupReading1.id,
-    groupReading1.reading_id,
-    decemberDate,
-  );
-  await addStudentReading(
-    2,
-    groupReading1.id,
-    groupReading1.reading_id,
-    decemberDate,
-  );
-
-  await prisma.evaluationGroupReading.create({
+  const groupReading4 = await prisma.evaluationGroupReading.create({
     data: {
       reading_id: testReading4.id,
       evaluation_group_id: testTeacher.GroupsOwned[0].id,
-      due_date: new Date('2024-09-10'),
+      due_date: februaryDate,
+      created_at: januaryDate,
     },
   });
 
-  await prisma.evaluationGroupReading.create({
+  const groupReading5 = await prisma.evaluationGroupReading.create({
     data: {
       reading_id: testReading5.id,
       evaluation_group_id: testTeacher.GroupsOwned[0].id,
-      due_date: new Date('2024-09-10'),
+      due_date: mayDate,
+      created_at: februaryDate,
     },
   });
 
+  const groupReading6 = await prisma.evaluationGroupReading.create({
+    data: {
+      reading_id: testReading6.id,
+      evaluation_group_id: testTeacher.GroupsOwned[0].id,
+      due_date: mayDate,
+      created_at: marchDate,
+    },
+  });
+
+  await addStudentReading(
+    1,
+    groupReading1.id,
+    groupReading1.reading_id,
+    octoberDate,
+  );
+  await addStudentReading(
+    1,
+    groupReading3.id,
+    groupReading3.reading_id,
+    decemberDate,
+  );
+  await addStudentReading(
+    1,
+    groupReading4.id,
+    groupReading4.reading_id,
+    januaryDate,
+  );
+  await addStudentReading(
+    1,
+    groupReading5.id,
+    groupReading5.reading_id,
+    februaryDate,
+  );
+  await addStudentReading(
+    1,
+    groupReading6.id,
+    groupReading6.reading_id,
+    marchDate,
+  );
+
+  await addStudentReading(
+    2,
+    groupReading1.id,
+    groupReading1.reading_id,
+    octoberDate,
+  );
+  await addStudentReading(
+    2,
+    groupReading2.id,
+    groupReading2.reading_id,
+    novemberDate,
+  );
+  await addStudentReading(
+    2,
+    groupReading3.id,
+    groupReading3.reading_id,
+    decemberDate,
+  );
+  await addStudentReading(
+    2,
+    groupReading4.id,
+    groupReading4.reading_id,
+    januaryDate,
+  );
+  await addStudentReading(
+    2,
+    groupReading5.id,
+    groupReading5.reading_id,
+    februaryDate,
+  );
+  await addStudentReading(
+    2,
+    groupReading6.id,
+    groupReading6.reading_id,
+    marchDate,
+  );
+
   await addStudents(testTeacher);
+
+  await addStudentReading(
+    3,
+    groupReading1.id,
+    groupReading1.reading_id,
+    octoberDate,
+  );
+  await addStudentReading(
+    3,
+    groupReading2.id,
+    groupReading2.reading_id,
+    novemberDate,
+  );
+  await addStudentReading(
+    3,
+    groupReading3.id,
+    groupReading3.reading_id,
+    decemberDate,
+  );
+  await addStudentReading(
+    3,
+    groupReading4.id,
+    groupReading4.reading_id,
+    januaryDate,
+  );
+  await addStudentReading(
+    3,
+    groupReading5.id,
+    groupReading5.reading_id,
+    februaryDate,
+  );
+  await addStudentReading(
+    3,
+    groupReading6.id,
+    groupReading6.reading_id,
+    marchDate,
+  );
+
+  await addStudentReading(
+    4,
+    groupReading1.id,
+    groupReading1.reading_id,
+    octoberDate,
+  );
+  await addStudentReading(
+    4,
+    groupReading2.id,
+    groupReading2.reading_id,
+    novemberDate,
+  );
+  await addStudentReading(
+    4,
+    groupReading3.id,
+    groupReading3.reading_id,
+    decemberDate,
+  );
+  await addStudentReading(
+    4,
+    groupReading4.id,
+    groupReading4.reading_id,
+    januaryDate,
+  );
+  await addStudentReading(
+    4,
+    groupReading5.id,
+    groupReading5.reading_id,
+    februaryDate,
+  );
+  await addStudentReading(
+    4,
+    groupReading6.id,
+    groupReading6.reading_id,
+    marchDate,
+  );
+
   await addAchievements();
 }
 

--- a/backend/src/controllers/evaluationGroups.controller.ts
+++ b/backend/src/controllers/evaluationGroups.controller.ts
@@ -180,70 +180,86 @@ export class EvaluationGroupsController {
       throw new UnprocessableEntityException('Evaluation group not found');
     }
 
-    const assignmentsDoneCount =
-      await this.prismaService.evaluationGroupReading.count({
-        where: {
+    const assignmentsDoneCount = await this.prismaService.recording.count({
+      where: {
+        EvaluationGroupReading: {
           evaluation_group_id: evaluationGroup.id,
-          Recordings: {
-            some: {
-              created_at: {
-                gte: dateFrom.toISOString(),
-                lte: dateTo.toISOString(),
-              },
-            },
+          created_at: {
+            gte: dateFrom.toISOString(),
+            lte: dateTo.toISOString(),
           },
         },
-      });
+      },
+    });
 
-    const now = new Date();
-    const inDateRangeCondition = {
-      AND: [
-        { created_at: { lte: dateTo.toISOString() } },
-        { due_date: { gte: dateFrom.toISOString() } },
-      ],
+    const assignmentsPending = (await this.prismaService.$queryRaw`
+      SELECT CAST(COUNT(1) AS INTEGER)
+      FROM "EvaluationGroupReading" egr
+      INNER JOIN "_EvaluationGroupToStudent" s ON s."A" = egr.evaluation_group_id
+      WHERE egr.evaluation_group_id = ${evaluationGroup.id}
+      AND egr.created_at BETWEEN ${dateFrom.toISOString()}::timestamp AND ${dateTo.toISOString()}::timestamp
+      AND egr.due_date > NOW()
+      AND NOT EXISTS (
+        SELECT 1 FROM "Recording" r
+        WHERE r.evaluation_group_reading_id = egr.id
+        AND r.student_id = s."B"
+      )
+    `) as {
+      count: number;
+    }[];
+
+    const assignmentsDelayed = (await this.prismaService.$queryRaw`
+      SELECT CAST(COUNT(1) AS INTEGER)
+      FROM "EvaluationGroupReading" egr
+      INNER JOIN "_EvaluationGroupToStudent" s ON s."A" = egr.evaluation_group_id
+      WHERE egr.evaluation_group_id = ${evaluationGroup.id}
+      AND egr.created_at BETWEEN ${dateFrom.toISOString()}::timestamp AND ${dateTo.toISOString()}::timestamp
+      AND egr.due_date <= NOW()
+      AND NOT EXISTS (
+        SELECT 1 FROM "Recording" r
+        WHERE r.evaluation_group_reading_id = egr.id
+        AND r.student_id = s."B"
+      )
+    `) as {
+      count: number;
     };
 
-    const assignmentsPendingCount =
-      await this.prismaService.evaluationGroupReading.count({
-        where: {
-          evaluation_group_id: evaluationGroup.id,
-          due_date: {
-            gt: now,
-          },
-          Recordings: {
-            none: {},
-          },
-          ...inDateRangeCondition,
-        },
-      });
-
-    const assignmentsDelayedCount =
-      await this.prismaService.evaluationGroupReading.count({
-        where: {
-          evaluation_group_id: evaluationGroup.id,
-          due_date: {
-            lt: now,
-          },
-          Recordings: {
-            none: {},
-          },
-          ...inDateRangeCondition,
-        },
-      });
-
     const monthlyAverages = (await this.prismaService.$queryRaw`
+      WITH evaluation_group_students AS (
+        SELECT
+          eg.id AS evaluation_group_id,
+          COUNT(s."B") AS total_students
+        FROM "EvaluationGroup" eg
+        JOIN "_EvaluationGroupToStudent" s ON s."A" = eg.id
+        WHERE eg.id = ${evaluationGroup.id}
+        GROUP BY eg.id
+      ),
+      readings_with_recordings AS (
+        SELECT
+          egr.evaluation_group_id,
+          egr.id AS egr_id,
+          egr.due_date,
+          COUNT(DISTINCT r.id) AS completed_assignments,
+          egs.total_students
+        FROM "EvaluationGroupReading" egr
+        JOIN evaluation_group_students egs ON egs.evaluation_group_id = egr.evaluation_group_id
+        LEFT JOIN "Recording" r ON egr.id = r.evaluation_group_reading_id
+        GROUP BY egr.evaluation_group_id, egr.id, egs.total_students
+      )
       SELECT
-        DATE_TRUNC('month', egr.created_at) as month,
-        AVG(a.score) as average_score,
-        CAST(COUNT(DISTINCT CASE WHEN r.id IS NOT NULL THEN egr.id END) AS INTEGER) as assignments_done,
-        CAST(COUNT(DISTINCT CASE WHEN r.id IS NULL AND egr.due_date > NOW() THEN egr.id END) AS INTEGER) as assignments_pending,
-        CAST(COUNT(DISTINCT CASE WHEN r.id IS NULL AND egr.due_date <= NOW() THEN egr.id END) AS INTEGER) as assignments_delayed
-      FROM "EvaluationGroupReading" egr
+        EXTRACT('month' FROM egr.created_at) AS month,
+        EXTRACT('year' FROM egr.created_at) AS year,
+        AVG(a.score) AS average_score,
+        SUM(rwr.completed_assignments) AS assignments_done,
+        SUM(rwr.total_students - rwr.completed_assignments) FILTER (WHERE egr.due_date > NOW()) AS assignments_pending,
+        SUM(rwr.total_students - rwr.completed_assignments) FILTER (WHERE egr.due_date <= NOW()) AS assignments_delayed
+      FROM readings_with_recordings rwr
+      JOIN "EvaluationGroupReading" egr ON rwr.egr_id = egr.id
       LEFT JOIN "Recording" r ON egr.id = r.evaluation_group_reading_id
       LEFT JOIN "Analysis" a ON r.id = a.recording_id
-      WHERE egr.evaluation_group_id = ${evaluationGroup.id}
-      GROUP BY DATE_TRUNC('month', egr.created_at)
-      ORDER BY month;
+      WHERE egr.created_at BETWEEN ${dateFrom.toISOString()}::timestamp AND ${dateTo.toISOString()}::timestamp
+      GROUP BY EXTRACT('year' FROM egr.created_at), EXTRACT('month' FROM egr.created_at)
+      ORDER BY EXTRACT('year' FROM egr.created_at), EXTRACT('month' FROM egr.created_at);
     `) as {
       month: Date;
       average_score: number;
@@ -254,23 +270,23 @@ export class EvaluationGroupsController {
 
     return {
       assignments_done: assignmentsDoneCount,
-      assignments_pending: assignmentsPendingCount,
-      assignments_delayed: assignmentsDelayedCount,
+      assignments_pending: assignmentsPending[0].count,
+      assignments_delayed: assignmentsDelayed[0].count,
       monthly_score_averages: monthlyAverages.map((m) => ({
-        month: m.month,
-        average_score: m.average_score || 0,
+        month: Number(m.month) - 1,
+        value: m.average_score || 0,
       })),
       monthly_assignments_done: monthlyAverages.map((m) => ({
-        month: m.month,
-        assignments_done: m.assignments_done || 0,
+        month: Number(m.month) - 1,
+        value: m.assignments_done || 0,
       })),
       monthly_assignments_pending: monthlyAverages.map((m) => ({
-        month: m.month,
-        assignments_pending: m.assignments_pending || 0,
+        month: Number(m.month) - 1,
+        value: m.assignments_pending || 0,
       })),
       monthly_assignments_delayed: monthlyAverages.map((m) => ({
-        month: m.month,
-        assignments_delayed: m.assignments_delayed || 0,
+        month: Number(m.month) - 1,
+        value: m.assignments_delayed || 0,
       })),
     };
   }
@@ -358,25 +374,20 @@ export class EvaluationGroupsController {
         }
       } else {
         const lastRecording = Recordings[Recordings.length - 1];
-        const recordingDate = dayjs(lastRecording.created_at);
-        const isInDateRange =
-          recordingDate.isAfter(dateFrom) && recordingDate.isBefore(dateTo);
 
-        if (isInDateRange) {
-          doneAssignmentsCount += 1;
+        doneAssignmentsCount += 1;
 
-          const lastAnalysis = lastRecording.Analysis.length
-            ? lastRecording.Analysis[lastRecording.Analysis.length - 1]
-            : null;
+        const lastAnalysis = lastRecording.Analysis.length
+          ? lastRecording.Analysis[lastRecording.Analysis.length - 1]
+          : null;
 
-          const isAnalysisCompleted =
-            lastAnalysis && lastAnalysis.status === AnalysisStatus.COMPLETED;
-          if (isAnalysisCompleted) {
-            addAverage('score', lastAnalysis.score);
-            addAverage('silences_count', lastAnalysis.silences_count);
-            addAverage('repetitions_count', lastAnalysis.repetitions_count);
-            addAverage('similarity_error', lastAnalysis.similarity_error);
-          }
+        const isAnalysisCompleted =
+          lastAnalysis && lastAnalysis.status === AnalysisStatus.COMPLETED;
+        if (isAnalysisCompleted) {
+          addAverage('score', lastAnalysis.score);
+          addAverage('silences_count', lastAnalysis.silences_count);
+          addAverage('repetitions_count', lastAnalysis.repetitions_count);
+          addAverage('similarity_error', lastAnalysis.similarity_error);
         }
       }
     });
@@ -388,8 +399,11 @@ export class EvaluationGroupsController {
     // Prisma does not support GROUP BY month for dates, so we have to use raw SQL
     const monthlyAverages = await this.prismaService.$queryRaw`
       SELECT
-        DATE_TRUNC('month', a.created_at) as month,
-        AVG(a.score) FILTER (WHERE r.student_id = ${student.id}) as student_avg_score,
+        (EXTRACT('month' FROM egr.created_at)::INTEGER - 1) as month,
+        EXTRACT('year' FROM egr.created_at)::INTEGER as year,
+        AVG(a.score) FILTER (WHERE r.student_id = ${
+          student.id
+        }) as student_avg_score,
         AVG(a.score) as group_avg_score
       FROM "Analysis" a
       JOIN "Recording" r ON a.recording_id = r.id
@@ -397,8 +411,9 @@ export class EvaluationGroupsController {
       JOIN "EvaluationGroupReading" egr ON r.evaluation_group_reading_id = egr.id
       JOIN "EvaluationGroup" eg ON egr.evaluation_group_id = eg.id
       WHERE eg.id = ${evaluationGroup.id}
-      GROUP BY DATE_TRUNC('month', a.created_at)
-      ORDER BY month;
+      AND egr.created_at between ${dateFrom.toISOString()}::timestamp and ${dateTo.toISOString()}::timestamp
+      GROUP BY EXTRACT('year' FROM egr.created_at), EXTRACT('month' FROM egr.created_at)
+      ORDER BY year ASC, month ASC;
     `;
 
     return {

--- a/frontend/src/api/teachers/hooks/useFetchGroupStats.tsx
+++ b/frontend/src/api/teachers/hooks/useFetchGroupStats.tsx
@@ -5,15 +5,6 @@ import dayjs from 'dayjs';
 
 const select = (data: GroupStats): GroupStats => ({
   ...data,
-  monthlyAssignmentsDelayed: [...data.monthlyAssignmentsDelayed].sort(
-    ({ month: lhm }, { month: rhm }) => lhm - rhm,
-  ),
-  monthlyAssignmentsDone: [...data.monthlyAssignmentsDone].sort(
-    ({ month: lhm }, { month: rhm }) => lhm - rhm,
-  ),
-  monthlyAssignmentsPending: [...data.monthlyAssignmentsPending].sort(
-    ({ month: lhm }, { month: rhm }) => lhm - rhm,
-  ),
 });
 
 const useFetchGroupStats = (

--- a/frontend/src/api/teachers/hooks/useFetchStudentStats.tsx
+++ b/frontend/src/api/teachers/hooks/useFetchStudentStats.tsx
@@ -5,9 +5,6 @@ import dayjs from 'dayjs';
 
 const select = (data: StudentStats): StudentStats => ({
   ...data,
-  monthlyAverages: [...data.monthlyAverages].sort(
-    ({ month: lhm }, { month: rhm }) => lhm - rhm,
-  ),
 });
 
 const useFetchStudentStats = (

--- a/frontend/src/api/teachers/teachers.ts
+++ b/frontend/src/api/teachers/teachers.ts
@@ -377,26 +377,6 @@ const parseStudentStatsResponse = (
   groupId: stats.group_id,
 });
 
-const parseMonthData = (monthAverages: StatsMonthItem[]): StatsMonthItem[] => {
-  if (monthAverages.length === 0) {
-    return [];
-  }
-
-  return monthAverages.map((monthItem) => {
-    var item = monthItem as any;
-    var value =
-      item.assignments_done ||
-      item.assignments_pending ||
-      item.assignments_delayed ||
-      item.score_average ||
-      0;
-    return {
-      month: dayjs.utc(monthItem.month).month(),
-      value: Number(value),
-    };
-  });
-};
-
 const parseGroupStatsResponse = (stats: GroupStatsResponse): GroupStats => ({
   assignmentsDone: stats.assignments_done,
   assignmentsDelayed: stats.assignments_delayed,

--- a/frontend/src/hooks/teachers/useChartJSInitializer.tsx
+++ b/frontend/src/hooks/teachers/useChartJSInitializer.tsx
@@ -11,6 +11,7 @@ import {
   Legend,
   BarElement,
   ArcElement,
+  Tooltip,
 } from 'chart.js';
 
 const useChartJSInitializer = () => {
@@ -26,6 +27,7 @@ const useChartJSInitializer = () => {
     RadialLinearScale,
     PieController,
     ArcElement,
+    Tooltip,
   );
 };
 

--- a/frontend/src/util/chart.ts
+++ b/frontend/src/util/chart.ts
@@ -9,6 +9,9 @@ export const chartOptions = (title: string) => {
           weight: '500',
         },
       },
+      tooltip: {
+        enabled: true,
+      },
     },
   };
 };


### PR DESCRIPTION
- Cambios en el seed para que haya más datos
- ⁠Fixes en las queries de estadisticas mensuales, estaban todas con algún error
- ⁠Agregué filtro por fecha a todas las queries de estadisticas
- ⁠Cambié como se determinaba el mes que mostrar, ahora retorna el número de mes (arrancando en 0) directo del backend, para no tener que ordenarlo y mapearlo en el front. Esto soluciona el orden de los meses incorrecto.
- Tooltips en todas las gráficas al hacer hover.