### PR TITLE
Fix de etiqueta en gráfico circular

### DIFF
--- a/frontend/src/pages/maestro/grupos/[grupo]/tarea/[tarea].tsx
+++ b/frontend/src/pages/maestro/grupos/[grupo]/tarea/[tarea].tsx
@@ -120,7 +120,7 @@ export default function Page({ params }: { params: Params }) {
     labels: mostRepeatedWords.map(({ word }) => word),
     datasets: [
       {
-        label: 'My First Dataset',
+        label: 'Repeticiones',
         data: mostRepeatedWords.map(({ repetitionCount }) => repetitionCount),
         backgroundColor: [
           'rgb(255, 99, 132)',


### PR DESCRIPTION
Ajusta etiqueta del tooltip en el gráfico circular de las tareas:

| Antes | Después |
|-|-|
| <img width="300" src="https://github.com/ucu-tesis/Ceibal/assets/47277080/c27bab2b-ce76-44a3-aca8-d93a456e7de3"> | <img width="300" src="https://github.com/ucu-tesis/Ceibal/assets/47277080/d096541f-9248-4715-a242-3f7c30f6d0ad"> |